### PR TITLE
Add Makefile for easy application startup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,61 @@
+.PHONY: help dev start backend frontend stop clean install
+
+# デフォルトターゲット
+.DEFAULT_GOAL := help
+
+help: ## ヘルプを表示
+	@echo "使用可能なコマンド:"
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}'
+
+dev: ## フロントエンドとバックエンドを並列起動（開発モード）
+	@echo "📦 アプリケーションを起動中..."
+	@trap 'kill 0' INT; \
+	(cd backend && ./gradlew :todo-api:bootRun) & \
+	(cd frontend && npm run dev) & \
+	wait
+
+start: dev ## devのエイリアス
+
+backend: ## バックエンドのみ起動
+	@echo "🚀 バックエンドを起動中..."
+	cd backend && ./gradlew :todo-api:bootRun
+
+frontend: ## フロントエンドのみ起動
+	@echo "🎨 フロントエンドを起動中..."
+	cd frontend && npm run dev
+
+install: ## 依存関係をインストール
+	@echo "📥 フロントエンド依存関係をインストール中..."
+	cd frontend && npm install
+	@echo "✅ インストール完了"
+
+build: ## プロジェクトをビルド
+	@echo "🔨 バックエンドをビルド中..."
+	cd backend && ./gradlew build
+	@echo "🔨 フロントエンドをビルド中..."
+	cd frontend && npm run build
+	@echo "✅ ビルド完了"
+
+test: ## テストを実行
+	@echo "🧪 バックエンドテストを実行中..."
+	cd backend && ./gradlew test
+	@echo "🧪 フロントエンドテストを実行中..."
+	cd frontend && npm test
+	@echo "✅ テスト完了"
+
+clean: ## ビルド成果物をクリーンアップ
+	@echo "🧹 クリーンアップ中..."
+	cd backend && ./gradlew clean
+	cd frontend && rm -rf dist node_modules/.vite
+	@echo "✅ クリーンアップ完了"
+
+stop: ## 起動中のプロセスを停止
+	@echo "🛑 アプリケーションを停止中..."
+	@pkill -f "todo-api:bootRun" || true
+	@pkill -f "vite" || true
+	@echo "✅ 停止完了"
+
+status: ## 起動中のプロセスを確認
+	@echo "📊 起動中のプロセス:"
+	@pgrep -fl "todo-api:bootRun" || echo "  バックエンド: 停止中"
+	@pgrep -fl "vite" || echo "  フロントエンド: 停止中"

--- a/README.md
+++ b/README.md
@@ -38,8 +38,35 @@ Spring AI の使い方を学ぶために作成した Todo アプリケーショ�
 - Java 17以上
 - Node.js 16以上
 - npm または yarn
+- make（オプション）
 
-### バックエンドの起動
+### 簡単な起動方法（Makefileを使用）
+
+```bash
+# 依存関係をインストール（初回のみ）
+make install
+
+# フロントエンドとバックエンドを同時に起動
+make dev
+# または
+make start
+
+# バックエンドのみ起動
+make backend
+
+# フロントエンドのみ起動
+make frontend
+
+# アプリケーションを停止
+make stop
+
+# ヘルプを表示
+make help
+```
+
+### 手動での起動
+
+#### バックエンドの起動
 
 ```bash
 cd backend
@@ -48,7 +75,7 @@ cd backend
 
 バックエンドは `http://localhost:8080` で起動します。
 
-### フロントエンドの起動
+#### フロントエンドの起動
 
 ```bash
 cd frontend


### PR DESCRIPTION
## Summary

フロントエンドとバックエンドを簡単に起動できるMakefileを追加しました。

## Changes

- **Makefile**: アプリケーション起動用の便利なコマンドを追加
  - `make dev/start`: 両方を並列起動
  - `make backend`: バックエンドのみ起動
  - `make frontend`: フロントエンドのみ起動
  - `make install`: 依存関係インストール
  - `make build`: プロジェクトビルド
  - `make test`: テスト実行
  - `make clean`: クリーンアップ
  - `make stop`: プロセス停止
  - `make status`: プロセス状態確認
  - `make help`: ヘルプ表示

- **README.md**: Makefileの使い方を追加

## Benefits

- 開発環境のセットアップが簡単に
- 1コマンドでフロントエンドとバックエンドを同時起動
- プロセス管理が容易に（停止、状態確認）
- 開発者体験の向上

## Test plan

- [x] `make help` でヘルプが表示されることを確認
- [x] `make stop` でプロセスが停止することを確認
- [x] `make dev` でフロントエンドとバックエンドが起動することを確認
- [x] Ctrl+C で両方のプロセスが停止することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)