### PR TITLE
Add lint checking functionality to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help dev start backend frontend stop clean install
+.PHONY: help dev start backend frontend stop clean install lint lint-fix
 
 # デフォルトターゲット
 .DEFAULT_GOAL := help
@@ -42,6 +42,20 @@ test: ## テストを実行
 	@echo "🧪 フロントエンドテストを実行中..."
 	cd frontend && npm test
 	@echo "✅ テスト完了"
+
+lint: ## Lintチェックを実行（バックエンド: ktlint、フロントエンド: ESLint）
+	@echo "🔍 バックエンドのLintチェックを実行中..."
+	cd backend && ./gradlew ktlintCheck
+	@echo "🔍 フロントエンドのLintチェックを実行中..."
+	cd frontend && npm run lint
+	@echo "✅ Lintチェック完了"
+
+lint-fix: ## Lintエラーを自動修正（バックエンド: ktlint format、フロントエンド: ESLint fix）
+	@echo "🔧 バックエンドのLintエラーを修正中..."
+	cd backend && ./gradlew ktlintFormat
+	@echo "🔧 フロントエンドのLintエラーを修正中..."
+	cd frontend && npm run lint -- --fix
+	@echo "✅ Lint修正完了"
 
 clean: ## ビルド成果物をクリーンアップ
 	@echo "🧹 クリーンアップ中..."

--- a/README.md
+++ b/README.md
@@ -64,6 +64,25 @@ make stop
 make help
 ```
 
+### 開発ツール
+
+```bash
+# テストを実行
+make test
+
+# Lintチェックを実行
+make lint
+
+# Lintエラーを自動修正
+make lint-fix
+
+# ビルドを実行
+make build
+
+# クリーンアップ
+make clean
+```
+
 ### 手動での起動
 
 #### バックエンドの起動

--- a/backend/todo-domain/src/test/kotlin/com/example/todo/domain/service/UserServiceTest.kt
+++ b/backend/todo-domain/src/test/kotlin/com/example/todo/domain/service/UserServiceTest.kt
@@ -56,7 +56,7 @@ class UserServiceTest {
     fun `findAll should return all users`() {
         val users = listOf(
             User(id = 1L, name = "user1"),
-            User(id = 2L, name = "user2")
+            User(id = 2L, name = "user2"),
         )
         whenever(userRepository.findAll()).thenReturn(users)
 


### PR DESCRIPTION
## Summary
- `make lint` コマンドを追加（バックエンド: ktlint、フロントエンド: ESLint）
- `make lint-fix` コマンドを追加（自動修正）
- README.md に開発ツールセクションを追加
- UserServiceTest.kt の ktlint 違反を修正（trailing comma）

## Changes
- **Makefile**: lint と lint-fix ターゲットを追加
- **README.md**: 開発ツールセクション（test, lint, lint-fix, build, clean）を追加
- **UserServiceTest.kt**: trailing comma を追加して ktlint ルールに準拠

## Test plan
- [x] `make lint` でバックエンドとフロントエンドの両方のチェックが実行されることを確認
- [x] `make lint-fix` でバックエンドのスタイル違反が自動修正されることを確認
- [x] バックエンドの ktlint チェックがすべてパスすることを確認

## Notes
フロントエンドには自動修正できない ESLint エラーが存在しますが、これらは既存のコードの設計上の問題であり、本 PR のスコープ外です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)