### PR TITLE
Fix all ESLint errors in frontend code

### DIFF
--- a/frontend/src/components/TodoForm.tsx
+++ b/frontend/src/components/TodoForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import type { Todo } from '../types';
 import type { User } from '../types/user';
 
@@ -10,21 +10,9 @@ interface TodoFormProps {
 }
 
 const TodoForm: React.FC<TodoFormProps> = ({ todo, users, onSubmit, onCancel }) => {
-  const [title, setTitle] = useState('');
-  const [dueDate, setDueDate] = useState('');
-  const [userId, setUserId] = useState<number | ''>('');
-
-  useEffect(() => {
-    if (todo) {
-      setTitle(todo.title);
-      setDueDate(todo.dueDate || '');
-      setUserId(todo.userId);
-    } else {
-      setTitle('');
-      setDueDate('');
-      setUserId(users.length > 0 ? users[0].id : '');
-    }
-  }, [todo, users]);
+  const [title, setTitle] = useState(todo?.title || '');
+  const [dueDate, setDueDate] = useState(todo?.dueDate || '');
+  const [userId, setUserId] = useState<number | ''>(todo?.userId || (users.length > 0 ? users[0].id : ''));
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();

--- a/frontend/src/components/UserForm.tsx
+++ b/frontend/src/components/UserForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import type { User } from '../types/user';
 
 interface UserFormProps {
@@ -8,15 +8,7 @@ interface UserFormProps {
 }
 
 const UserForm: React.FC<UserFormProps> = ({ user, onSubmit, onCancel }) => {
-  const [name, setName] = useState('');
-
-  useEffect(() => {
-    if (user) {
-      setName(user.name);
-    } else {
-      setName('');
-    }
-  }, [user]);
+  const [name, setName] = useState(user?.name || '');
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();


### PR DESCRIPTION
## Summary
フロントエンドの全 ESLint エラー（12件）を修正しました。

## Changes

### 1. useEffect 内の setState 問題を修正 (TodoForm, UserForm)
- useEffect を削除し、useState の初期値を props から直接計算
- 親コンポーネントに `key` プロパティを追加して編集時に再マウント

### 2. any 型の使用を修正 (TodoListPage, UsersPage)
- `any` 型を `unknown` に変更
- `isAxiosError()` による型ガードを実装
- エラーハンドリングの型安全性を向上

### 3. useEffect の依存配列の問題を修正 (TodoListPage, UsersPage)
- `useCallback` で fetch 関数をメモ化
- 適切な依存配列を設定

## Test plan
- [x] `npm run lint` でエラーがないことを確認
- [x] `npm test` ですべてのテストが通過することを確認
- [x] `make lint` でバックエンド・フロントエンド共に成功することを確認

## Results
- **ESLint エラー**: 12 → 0
- **テスト**: 5/5 通過
- **コード品質**: 型安全性が向上

🤖 Generated with [Claude Code](https://claude.com/claude-code)